### PR TITLE
Fixed deprecated meta api usage for django 1.8, module_name was renam…

### DIFF
--- a/mezzanine_page_auth/models.py
+++ b/mezzanine_page_auth/models.py
@@ -21,7 +21,7 @@ class PageAuthGroup(models.Model):
         unique_together = ("page", "group")
 
     def __str__(self):
-        return u"{}: {} has {}".format(self._meta.module_name, self.group.name,
+        return u"{}: {} has {}".format(self._meta.model_name, self.group.name,
                                        self.page)
 
     @classmethod


### PR DESCRIPTION
### error:

Django Version:     1.8.4
Exception Type:     AttributeError
Exception Value:    'Options' object has no attribute 'module_name'

Fixed deprecated meta api usage for django 1.8, module_name was renamed to model_name
